### PR TITLE
VKontakte backend implementation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ django>=1.2.5
 django-social-auth>=0.7.10
 python-twitter>=0.8.2
 git+https://github.com/pythonforfacebook/facebook-sdk.git
+vkontakte>=1.3.2

--- a/social_friends_finder/backends/vkontakte_backend.py
+++ b/social_friends_finder/backends/vkontakte_backend.py
@@ -1,0 +1,47 @@
+from social_friends_finder.backends import BaseFriendsProvider
+from social_friends_finder.utils import setting
+if not setting("SOCIAL_FRIENDS_USING_ALLAUTH", False):
+    from social_auth.backends.contrib.vkontakte import VKontakteOAuth2Backend
+    USING_ALLAUTH = False
+else:
+    from allauth.socialaccount.models import SocialToken, SocialAccount, SocialApp
+    USING_ALLAUTH = True
+import vkontakte
+
+
+class VKontakteFriendsProvider(BaseFriendsProvider):
+
+    def fetch_friends(self, user):
+        """
+        fethces friends from VKontakte using the access_token
+        fethched by django-social-auth.
+
+        Note - user isn't a user - it's a UserSocialAuth if using social auth, or a SocialAccount if using allauth
+
+        Returns:
+            collection of friend objects fetched from VKontakte
+        """
+
+        if USING_ALLAUTH:
+            raise NotImplementedError("VKontakte support is not implemented for django-allauth")
+            #social_app = SocialApp.objects.get_current('vkontakte')
+            #oauth_token = SocialToken.objects.get(account=user, app=social_app).token
+        else:
+            social_auth_backend = VKontakteOAuth2Backend()
+
+            # Get the access_token
+            tokens = social_auth_backend.tokens(user)
+            oauth_token = tokens['access_token']
+
+        api = vkontakte.API(token=oauth_token)
+        return api.get("friends.get")
+
+    def fetch_friend_ids(self, user):
+        """
+        fetches friend id's from vkontakte
+
+        Return:
+            collection of friend ids
+        """
+        friend_ids = self.fetch_friends(user)
+        return friend_ids

--- a/social_friends_finder/utils.py
+++ b/social_friends_finder/utils.py
@@ -14,6 +14,9 @@ class SocialFriendsFinderBackendFactory():
         elif backend_name == 'facebook':
             from social_friends_finder.backends.facebook_backend import FacebookFriendsProvider
             friends_provider = FacebookFriendsProvider()
+        elif backend_name == 'vkontakte-oauth2':
+            from social_friends_finder.backends.vkontakte_backend import VKontakteFriendsProvider
+            friends_provider = VKontakteFriendsProvider()
         else:
             raise NotImplementedError("provider: %s is not implemented")
 


### PR DESCRIPTION
VKontakte (vk.com) is a largest social network in Russia and some other countries. It has more than 60 mil users. 
It has OAuth2 support, and there is implementation in django-social-auth, but unfortunately not in django-allauth.
I raise NotImplementedError for case with django-allauth.
